### PR TITLE
Support multiple shared schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Choose app-store, `"ad-hoc"`, `"package"` `"enterprise"`, `"development"`, or `"
 
 For example, `"Debug"`, `"Release"`. Default `"Release"`.
 
+### `scheme`
+
+For example, `"myscheme"`.
+
 ### `certificate-password`
 
 Certificate password. Default `""`.

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
     description: "Output path of ipa"
     required: false
     default: "output.ipa"
+  scheme:
+    description: "Scheme"
+    required: true
 runs:
   using: "node12"
   main: "index.js"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,6 +36,7 @@ platform :ios do
       build_app(
         workspace: ENV["WORKSPACE_PATH"],
         configuration: ENV["CONFIGURATION"],
+        scheme: ENV["SCHEME"],
         output_name: ENV["OUTPUT_PATH"],
         clean: true,
         export_method: ENV["EXPORT_METHOD"]
@@ -44,6 +45,7 @@ platform :ios do
       build_app(
         project: ENV["PROJECT_PATH"],
         configuration: ENV["CONFIGURATION"],
+        scheme: ENV["SCHEME"],
         output_name: ENV["OUTPUT_PATH"],
         clean: true,
         export_method: ENV["EXPORT_METHOD"]

--- a/index.js
+++ b/index.js
@@ -5,7 +5,9 @@ async function run() {
   try {
     process.env.PROJECT_PATH = core.getInput("project-path");
     process.env.P12_BASE64 = core.getInput("p12-base64");
-    process.env.MOBILEPROVISION_BASE64 = core.getInput("mobileprovision-base64");
+    process.env.MOBILEPROVISION_BASE64 = core.getInput(
+      "mobileprovision-base64"
+    );
     process.env.CODE_SIGNING_IDENTITY = core.getInput("code-signing-identity");
     process.env.TEAM_ID = core.getInput("team-id");
     process.env.WORKSPACE_PATH = core.getInput("workspace-path");
@@ -13,6 +15,7 @@ async function run() {
     process.env.CONFIGURATION = core.getInput("configuration");
     process.env.CERTIFICATE_PASSWORD = core.getInput("certificate-password");
     process.env.OUTPUT_PATH = core.getInput("output-path");
+    process.env.SCHEME = core.getInput("scheme");
 
     await exec.exec(`/bin/bash ${__dirname}/build.sh`);
   } catch (error) {


### PR DESCRIPTION
iOS projects which share multiple schemes fail with `Multiple schemes found but you haven't specified one.`. This PR passes a configurable scheme to fastlanes build_app to resolve this.