### PR TITLE
Support split certificate/key p12 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 This action build iOS project. (.xcodeproj, .xcworkspace)
 
-And, can export to ipa, so it can be continuously delivered to DeployGate and TestFlight.
+And can export to ipa, so it can be continuously delivered to DeployGate and TestFlight.
+
+You can add a single p12 key+cert file with `p12-base64`, or if you have key and cert in separate files
+you can add them with `p12-key-base64` and `p12-cer-base64`. One of the two options is required.
 
 ## Inputs
 
@@ -12,7 +15,15 @@ And, can export to ipa, so it can be continuously delivered to DeployGate and Te
 
 ### `p12-base64`
 
-**Required** Base64 encoded p12 file.
+**Required if single file**: Base64 encoded p12 file (key + cert).
+
+### `p12-key-base64`
+
+**Required if split key/cert**: Base64 encoded p12 key file.
+
+### `p12-cer-base64`
+
+**Required if split key/cert**: Base64 encoded certificate for the p12 key.
 
 ### `mobileprovision-base64`
 
@@ -69,4 +80,5 @@ Welcome your contributions!
     code-signing-identity: ${{ secrets.CODE_SIGNING_IDENTITY }}
     team-id: ${{ secrets.TEAM_ID }}
     workspace-path: Unity-iPhone.xcworkspace
+    export-method: development
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,18 @@
 name: "iOS Build Action"
-description: "Export ipa"
+description: "Create an IPA file from ios source"
 inputs:
   project-path:
     description: "Project path"
     required: true
+  p12-key-base64:
+    description: "Base64 encoded p12 key"
+    required: false
+  p12-cer-base64:
+    description: "Base64 encoded certificate for the p12 key"
+    required: false
   p12-base64:
-    description: "Base64 encoded p12 file"
-    required: true
+    description: "Base64 encoded p12 file (key + cert)"
+    required: false
   mobileprovision-base64:
     description: "Base64 encoded mobileprovision file"
     required: true

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,12 @@ fi
 script_path=$(cd $(dirname ${0}); pwd)
 cp -r ${script_path}/fastlane ./
 
-echo $P12_BASE64 | base64 --decode > ios-build.p12
+if [[ ! -z $P12_KEY_BASE64 && ! -z $P12_CER_BASE64 ]]; then
+    echo $P12_KEY_BASE64 | base64 --decode > ios-build-key.p12
+    echo $P12_CER_BASE64 | base64 --decode > ios-build-key.cer
+    export CERTIFICATE_SPLIT=1
+else
+    echo $P12_BASE64 | base64 --decode > ios-build.p12
+fi
 echo $MOBILEPROVISION_BASE64 | base64 --decode > ios-build.mobileprovision
-
 fastlane export_ipa

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,12 +11,30 @@ platform :ios do
       unlock: true,
       timeout: 3600
     )
-    import_certificate(
-      certificate_path: "ios-build.p12",
-      certificate_password: ENV["CERTIFICATE_PASSWORD"],
-      keychain_name: "ios-build.keychain",
-      keychain_password: keychain_password
-    )
+    if ENV["CERTIFICATE_SPLIT"] == '1'
+      import_certificate(
+        certificate_path: "ios-build-key.p12",
+        certificate_password: ENV["CERTIFICATE_PASSWORD"],
+        keychain_name: "ios-build.keychain",
+        keychain_password: keychain_password,
+        log_output: true
+      )
+      import_certificate(
+        certificate_path: "ios-build-key.cer",
+        certificate_password: ENV["CERTIFICATE_PASSWORD"],
+        keychain_name: "ios-build.keychain",
+        keychain_password: keychain_password,
+        log_output: true
+      )
+    else
+      import_certificate(
+        certificate_path: "ios-build.p12",
+        certificate_password: ENV["CERTIFICATE_PASSWORD"],
+        keychain_name: "ios-build.keychain",
+        keychain_password: keychain_password,
+        log_output: true
+      )
+    end
     install_provisioning_profile(
       path: "ios-build.mobileprovision"
     )

--- a/index.js
+++ b/index.js
@@ -3,8 +3,15 @@ const exec = require("@actions/exec");
 
 async function run() {
   try {
+    // Validate p12 keys.
+    if (!core.getInput("p12-base64")
+      && (!core.getInput("p12-cer-base64") || !core.getInput("p12-cer-base64"))) {
+      throw new Error("P12 keys missing or in the wrong format.");
+    }
     process.env.PROJECT_PATH = core.getInput("project-path");
     process.env.P12_BASE64 = core.getInput("p12-base64");
+    process.env.P12_KEY_BASE64 = core.getInput("p12-key-base64");
+    process.env.P12_CER_BASE64 = core.getInput("p12-cer-base64");
     process.env.MOBILEPROVISION_BASE64 = core.getInput(
       "mobileprovision-base64"
     );


### PR DESCRIPTION
We needed to have two different files for p12 key and certificate. This PR adds the possibility to either pass the single file parameter or the two files, as reported in the updated README.