### PR TITLE
Update Fastfile to fix potential provisionning error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,10 @@ inputs:
     description: "Scheme"
     required: false
     default: ""
+  disable-targets:
+    description: "Targets to disable automatic code signing. Input targets separated by ,. For example, 'MyApp,YourApp'."
+    required: false
+    default: ""
 runs:
   using: "node12"
   main: "index.js"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -38,8 +38,10 @@ platform :ios do
     install_provisioning_profile(
       path: "ios-build.mobileprovision"
     )
-    disable_automatic_code_signing(
-      path: ENV["PROJECT_PATH"]
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: ENV["PROJECT_PATH"],
+      targets: "Unity-iPhone"
     )
     update_project_provisioning(
       xcodeproj: ENV["PROJECT_PATH"],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -38,10 +38,12 @@ platform :ios do
     install_provisioning_profile(
       path: "ios-build.mobileprovision"
     )
+    disable_targets = ENV["DISABLE_TARGETS"]&.split(/,/)
     update_code_signing_settings(
       use_automatic_signing: false,
       path: ENV["PROJECT_PATH"],
-      targets: "Unity-iPhone"
+      targets: disable_targets
+)
     )
     update_project_provisioning(
       xcodeproj: ENV["PROJECT_PATH"],

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ async function run() {
     process.env.CERTIFICATE_PASSWORD = core.getInput("certificate-password");
     process.env.OUTPUT_PATH = core.getInput("output-path");
     process.env.SCHEME = core.getInput("scheme");
-
+    process.env.DISABLE_TARGETS = core.getInput("disable-targets");
     await exec.exec(`bash ${__dirname}/build.sh`);
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
Had this error when building for ios : 
```
Check dependencies
[BCEROR]Code Signing Error: UnityFramework does not support provisioning profiles. UnityFramework does not support provisioning profiles, but provisioning profile KravmagaProfile has been manually specified. Set the provisioning profile value to "Automatic" in the build settings editor.
```

Changes fastlane file to use the lastest method to update only the Unity-iPhone target (the only one that needs a profile)