### PR TITLE
Added disable automatic signing for input targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Certificate password. Default `""`.
 
 Output path of ipa. Default `"output.ipa"`.
 
+### `disable-targets`
+
+These targets will not use automatic code signing and instead use the identity specified in other inputs. Input targets separated by ','. For example, 'MyApp,YourApp'. Default: ""
+
 ## Contributions Welcome!
 
 If you have any other inputs you'd like to add, feel free to create PR.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Output path of ipa. Default `"output.ipa"`.
 
 ### `disable-targets`
 
-These targets will not use automatic code signing and instead use the identity specified in other inputs. Input targets separated by ','. For example, 'MyApp,YourApp'. Default: ""
+These targets will not use automatic code signing and instead use the identity specified in other inputs. Input targets separated by ','. For example, 'MyApp,YourApp'. Default "".  (default to all targets)
 
 ## Contributions Welcome!
 

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,10 @@ inputs:
     description: "Scheme"
     required: false
     default: ""
+  disable-targets:
+    description: "Targets to disable automatic code signing. Input targets separated by ,. For example, 'MyApp,YourApp'."
+    required: false
+    default: ""
 runs:
   using: "node12"
   main: "index.js"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -38,9 +38,12 @@ platform :ios do
     install_provisioning_profile(
       path: "ios-build.mobileprovision"
     )
-    disable_automatic_code_signing(
-      path: ENV["PROJECT_PATH"]
-    )
+    disable_targets = ENV["DISABLE_TARGETS"]&.split(/,/)
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: ENV["PROJECT_PATH"],
+      targets: disable_targets
+	)
     update_project_provisioning(
       xcodeproj: ENV["PROJECT_PATH"],
       profile: "ios-build.mobileprovision",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -43,7 +43,7 @@ platform :ios do
       use_automatic_signing: false,
       path: ENV["PROJECT_PATH"],
       targets: disable_targets
-	)
+    )
     update_project_provisioning(
       xcodeproj: ENV["PROJECT_PATH"],
       profile: "ios-build.mobileprovision",

--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ async function run() {
     process.env.CERTIFICATE_PASSWORD = core.getInput("certificate-password");
     process.env.OUTPUT_PATH = core.getInput("output-path");
     process.env.SCHEME = core.getInput("scheme");
-
+	process.env.DISABLE_TARGETS = core.getInput("disable-targets");
+	
     await exec.exec(`bash ${__dirname}/build.sh`);
   } catch (error) {
     core.setFailed(error.message);

--- a/index.js
+++ b/index.js
@@ -23,8 +23,7 @@ async function run() {
     process.env.CERTIFICATE_PASSWORD = core.getInput("certificate-password");
     process.env.OUTPUT_PATH = core.getInput("output-path");
     process.env.SCHEME = core.getInput("scheme");
-	process.env.DISABLE_TARGETS = core.getInput("disable-targets");
-	
+    process.env.DISABLE_TARGETS = core.getInput("disable-targets");
     await exec.exec(`bash ${__dirname}/build.sh`);
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
Had this error when building for ios :

```
Check dependencies
[BCEROR]Code Signing Error: UnityFramework does not support provisioning profiles. UnityFramework does not support provisioning profiles, but provisioning profile KravmagaProfile has been manually specified. Set the provisioning profile value to "Automatic" in the build settings editor.
```

Changes fastlane file to use the lastest method to update only the targets specified in disable-targets.