### PR TITLE
Add code_sign_identity to update_code_signing_settings

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,6 +51,7 @@ platform :ios do
     update_code_signing_settings(
       use_automatic_signing: false,
       path: ENV['PROJECT_PATH'],
+      code_sign_identity: ENV['CODE_SIGNING_IDENTITY'],
       targets: update_targets
     )
 
@@ -58,7 +59,6 @@ platform :ios do
       update_project_provisioning(
         xcodeproj: ENV['PROJECT_PATH'],
         profile: @profiles[0],
-        code_signing_identity: ENV['CODE_SIGNING_IDENTITY'],
         target_filter:
           update_targets.map { |target| "^#{Regexp.escape(target)}$" }.join('|')
       )


### PR DESCRIPTION
Fix `error: No signing certificate "iOS Development" found: No "iOS Development" signing certificate matching team ID "***" with a private key was found. (in target 'my_project' from project 'my_project')`.

https://github.com/yukiarrr/ios-build-action/issues/40
https://github.com/yukiarrr/ios-build-action/issues/45