### PR TITLE
Updated readme to avoid issues with multiline base64 provisioning profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can add a single p12 key+cert file with `p12-base64`, or if you have key and
       ${{ secrets.YOUR_MOBILEPROVISION_BASE64 }}
 ```
 
-> NOTE:- when creating base64 encoded inputs, make sure they don't contain newlines, e.g.
+Also note, when creating base64 encoded inputs, make sure they don't contain newlines, e.g.
 
     openssl base64 -in MyAppProvisioning.mobileprovision -A
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ You can add a single p12 key+cert file with `p12-base64`, or if you have key and
       ${{ secrets.YOUR_MOBILEPROVISION_BASE64 }}
 ```
 
+> NOTE:- when creating base64 encoded inputs, make sure they don't contain newlines, e.g.
+
+    openssl base64 -in MyAppProvisioning.mobileprovision -A
+
 ### `project-path`
 
 **Required**: .xcodeproj path.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -201,7 +201,6 @@ platform :ios do
     ) do |profile, index|
       filename = "ios-build-#{index}.mobileprovision"
       puts "creating ../#{filename}"
-      puts "using #{Base64.decode64(profile)}"
       File.write("../#{filename}", Base64.decode64(profile))
       @profiles.push(filename)
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -195,13 +195,13 @@ platform :ios do
       File.write('../ios-build.p12', Base64.decode64(ENV['P12_BASE64']))
     end
 
-    puts ENV['MOBILEPROVISION_BASE64']
-
     @profiles = []
     ENV['MOBILEPROVISION_BASE64'].split(/\R/).each.with_index(
       1
     ) do |profile, index|
       filename = "ios-build-#{index}.mobileprovision"
+      puts "creating ../#{filename}"
+      puts "using #{Base64.decode64(profile)}"
       File.write("../#{filename}", Base64.decode64(profile))
       @profiles.push(filename)
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -195,6 +195,8 @@ platform :ios do
       File.write('../ios-build.p12', Base64.decode64(ENV['P12_BASE64']))
     end
 
+    puts ENV['MOBILEPROVISION_BASE64']
+
     @profiles = []
     ENV['MOBILEPROVISION_BASE64'].split(/\R/).each.with_index(
       1


### PR DESCRIPTION
Was getting this error https://github.com/yukiarrr/ios-build-action/issues/42#issuecomment-756058146

Noticed several hundred `ios-build-n..mobileprovision` files being generated then failure to parse. Turns out the default base64 output of `openssl` with its newlines was causing the issue. I've just updated the `README.md` as an fyi/quick workaround.