### PR TITLE
Support custom entitlements path for update_code_signing_settings function

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ Path to an export options plist. Default `""`.
 
 Path for Swift Package Manager dependencies. Default `""`.
 
+### `entitlements-file-path`
+
+Path to your entitlements file. Default `""`.
+
 ### `build-sdk`
 
 The SDK that should be used for building the application. Default `""`. For example, `"iOS 11.1"`.

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "iOS Build Action"
-description: "Build iOS project (.xcodeproj, .xcworkspace), and export ipa"
+description: "Build iOS project (.xcodeproj, .xcworkspace), and export ipa with custom entitlements"
 inputs:
   p12-key-base64:
     description: "Base64 encoded p12 key"
@@ -80,6 +80,10 @@ inputs:
     default: ""
   cloned-source-packages-path:
     description: "Path for Swift Package Manager dependencies"
+    required: false
+    default: ""
+  entitlements-file-path:
+    description: "Path to your entitlements file"
     required: false
     default: ""
 runs:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -64,7 +64,8 @@ platform :ios do
       use_automatic_signing: false,
       path: ENV['PROJECT_PATH'],
       code_sign_identity: ENV['CODE_SIGNING_IDENTITY'],
-      targets: update_targets
+      targets: update_targets,
+      entitlements_file_path: ENV['ENTITLMENTS_FILE_PATH']
     )
 
     if @profiles.length == 1

--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ async function run() {
     );
     process.env.BUILD_SDK = core.getInput("build-sdk");
     process.env.BUILD_DESTINATION = core.getInput("build-destination");
+    process.env.ENTITLMENTS_FILE_PATH = core.getInput("entitlements-file-path");
 
     // Execute build.sh
     await exec.exec(`bash ${__dirname}/../build.sh`);


### PR DESCRIPTION
Resolves #91. Adds an option to provide entitlements_file_path to support custom setups (i.e. where each build target has a custom entitlements file).

Done:

- Update documentation to show how to use it
- Add parameter to action.yml and parse it as environment for fastlane to use
- Add it to fastlane update_code_signing_settings function