### PR TITLE
feat: input for incrementing the version number and build number improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,37 @@ The SDK that should be used for building the application. Default `""`. For exam
 
 Use a custom destination for building the app. Default `""`. For example, `"generic/platform=iOS"`.
 
+### `increment-version-number`
+
+Increment the version number of your project. Supports `"patch"`, `"minor"`, `"major"` or a specific version number. Default `""`.
+
 ### `increment-build-number`
 
-Automatically increment the build number by one before building the application. Default `false`.
+Increment the build number before building the application. Default `""`.
+
+ - `true` - automatically increment the project build number by one
+ - `testflight` - increment the latest TestFlight build number by one. If this is specified you must also provide `bundle-identifier`, `app-store-connect-api-key-id`, `app-store-connect-api-key-issuer-id` and `app-store-connect-api-key-base64`
+ - a specific build number e.g. `75`
+
+
+### `bundle-identifier`
+
+Application bundle identifier. Default `""`.
+
+### `app-store-connect-api-key-id`
+
+App Store Connect API Key ID. Default `""`.
+
+
+### `app-store-connect-api-key-issuer-id`
+
+App Store Connect API Key Issuer ID. Default `""`.
+
+
+### `app-store-connect-api-key-base64`
+
+Base64 encoded App Store Connect API Key. Default `""`.
+
 
 ## Contributions Welcome!
 

--- a/action.yml
+++ b/action.yml
@@ -87,9 +87,29 @@ inputs:
     required: false
     default: ""
   increment-build-number: 
-    description: "Automatically increment the build number by one before building the application"
+    description: "Increment the build number before building the application"
     required: false
-    default: false
+    default: ""
+  increment-version-number:
+    description: 'Increment the version number of your project. Supports patch, minor, major or a specific version number.'
+    required: false
+    default: ""
+  bundle-identifier:
+    description: 'Bundle identifier of the application.'
+    required: false
+    default: ""
+  app-store-connect-api-key-id:
+    description: 'App Store Connect API Key ID'
+    required: false
+    default: ""
+  app-store-connect-api-key-issuer-id:
+    description: 'App Store Connect API Key Issuer ID'
+    required: false
+    default: ""
+  app-store-connect-api-key-base64:
+    description: 'Base64 encoded App Store Connect API Key'
+    required: false
+    default: ""
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -28,6 +28,14 @@ async function run() {
       throw new Error("mobileprovision missing or in the wrong format.");
     }
 
+    // Validate increment build number
+    if (
+      core.getInput("increment-build-number") === "testflight" &&
+      (!core.getInput("bundle-identifier") || !core.getInput("app-store-connect-api-key-id") || !core.getInput("app-store-connect-api-key-issuer-id") || !core.getInput("app-store-connect-api-key-base64"))
+    ) {
+      throw new Error("increment-build-number='testflight' requires 'bundle-identifier', 'app-store-connect-api-key-id', 'app-store-connect-api-key-issuer-id' and 'app-store-connect-api-key-base64' to be provided.");
+    }
+
     // Set environment variables
     process.env.P12_BASE64 = core.getInput("p12-base64");
     process.env.P12_KEY_BASE64 = core.getInput("p12-key-base64");
@@ -58,6 +66,12 @@ async function run() {
     process.env.BUILD_DESTINATION = core.getInput("build-destination");
     process.env.ENTITLMENTS_FILE_PATH = core.getInput("entitlements-file-path");
     process.env.INCREMENT_BUILD_NUMBER = core.getInput("increment-build-number");
+    process.env.INCREMENT_VERSION_NUMBER = core.getInput('increment-version-number');
+    process.env.BUNDLE_IDENTIFIER = core.getInput('bundle-identifier');
+    process.env.APP_STORE_CONNECT_API_KEY_ID = core.getInput('app-store-connect-api-key-id');
+    process.env.APP_STORE_CONNECT_API_KEY_ISSUER_ID = core.getInput('app-store-connect-api-key-issuer-id');
+    process.env.APP_STORE_CONNECT_API_KEY_BASE64 = core.getInput('app-store-connect-api-key-base64');
+
 
     // Execute build.sh
     await exec.exec(`bash ${__dirname}/../build.sh`);

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -146,8 +146,45 @@ platform :ios do
     use_build_destination = !ENV['BUILD_DESTINATION'].empty?
     use_cloned_source_packages_path = !ENV['CLONED_SOURCE_PACKAGES_PATH'].empty?
 
-    if ENV['INCREMENT_BUILD_NUMBER'] == 'true'
-      increment_build_number(xcodeproj: ENV['PROJECT_PATH'])
+    if !ENV['INCREMENT_BUILD_NUMBER'].empty?
+      if ENV['INCREMENT_BUILD_NUMBER'] == 'true'
+        increment_build_number(xcodeproj: ENV['PROJECT_PATH'])
+      elsif ENV['INCREMENT_BUILD_NUMBER'] == 'testflight'
+        api_key = app_store_connect_api_key(
+          key_id: ENV['APP_STORE_CONNECT_API_KEY_ID'],
+          issuer_id: ENV['APP_STORE_CONNECT_API_KEY_ISSUER_ID'],
+          key_content: ENV['APP_STORE_CONNECT_API_KEY_BASE64'],
+          is_key_content_base64: true
+        )
+        current_testflight_build_number = latest_testflight_build_number(
+          api_key: api_key,
+          app_identifier: ENV["BUNDLE_IDENTIFIER"],
+          team_id: ENV['TEAM_ID']
+        )
+        increment_build_number(
+          build_number: current_testflight_build_number + 1,
+          xcodeproj: ENV['PROJECT_PATH']
+        )
+      else
+        increment_build_number(
+          build_number: ENV['INCREMENT_BUILD_NUMBER'],
+          xcodeproj: ENV['PROJECT_PATH']
+        )
+      end
+    end
+
+    if !ENV['INCREMENT_VERSION_NUMBER'].empty?
+      if ["patch", "minor", "major"].include?(ENV['INCREMENT_VERSION_NUMBER'])
+        increment_version_number(
+          bump_type: ENV['INCREMENT_VERSION_NUMBER'],
+          xcodeproj: ENV['PROJECT_PATH']
+        )
+      else
+        increment_version_number(
+          version_number: ENV['INCREMENT_VERSION_NUMBER'],
+          xcodeproj: ENV['PROJECT_PATH']
+        )
+      end
     end
 
     build_app(

--- a/index.js
+++ b/index.js
@@ -21,6 +21,14 @@ async function run() {
       throw new Error("mobileprovision missing or in the wrong format.");
     }
 
+    // Validate increment build number
+    if (
+      core.getInput("increment-build-number") === "testflight" &&
+      (!core.getInput("bundle-identifier") || !core.getInput("app-store-connect-api-key-id") || !core.getInput("app-store-connect-api-key-issuer-id") || !core.getInput("app-store-connect-api-key-base64"))
+    ) {
+      throw new Error("increment-build-number='testflight' requires 'bundle-identifier', 'app-store-connect-api-key-id', 'app-store-connect-api-key-issuer-id' and 'app-store-connect-api-key-base64' to be provided.");
+    }
+
     // Set environment variables
     process.env.P12_BASE64 = core.getInput("p12-base64");
     process.env.P12_KEY_BASE64 = core.getInput("p12-key-base64");
@@ -51,6 +59,11 @@ async function run() {
     process.env.BUILD_DESTINATION = core.getInput("build-destination");
     process.env.ENTITLMENTS_FILE_PATH = core.getInput("entitlements-file-path");
     process.env.INCREMENT_BUILD_NUMBER = core.getInput("increment-build-number");
+    process.env.INCREMENT_VERSION_NUMBER = core.getInput('increment-version-number');
+    process.env.BUNDLE_IDENTIFIER = core.getInput('bundle-identifier');
+    process.env.APP_STORE_CONNECT_API_KEY_ID = core.getInput('app-store-connect-api-key-id');
+    process.env.APP_STORE_CONNECT_API_KEY_ISSUER_ID = core.getInput('app-store-connect-api-key-issuer-id');
+    process.env.APP_STORE_CONNECT_API_KEY_BASE64 = core.getInput('app-store-connect-api-key-base64');
 
     // Execute build.sh
     await exec.exec(`bash ${__dirname}/../build.sh`);


### PR DESCRIPTION
- Introduction of a new `increment-version-number` allowing `"patch"`, `"minor"`, `"major"` or a specific version number
- Extend capabilities of `increment-build-number` to support different increment options
  - Increment of current project build number by one
  - Increment of current TestFlight build number by one
  - User-specified build number