### PR TITLE
[WIP] add export_team_id option

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -205,7 +205,7 @@ platform :ios do
       export_options: use_export_options ? ENV['EXPORT_OPTIONS'] : nil,
       skip_profile_detection: use_export_options,
       sdk: use_build_sdk ? ENV['BUILD_SDK'] : nil,
-      destination: use_build_destination ? ENV['BUILD_DESTINATION'] : nil
+      destination: use_build_destination ? ENV['BUILD_DESTINATION'] : nil,
       export_team_id: ENV['EXPORT_TEAM_ID']
     )
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -206,6 +206,7 @@ platform :ios do
       skip_profile_detection: use_export_options,
       sdk: use_build_sdk ? ENV['BUILD_SDK'] : nil,
       destination: use_build_destination ? ENV['BUILD_DESTINATION'] : nil
+      export_team_id: ENV['EXPORT_TEAM_ID']
     )
 
     delete_keychain(name: 'ios-build.keychain')

--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ async function run() {
     process.env.APP_STORE_CONNECT_API_KEY_ID = core.getInput('app-store-connect-api-key-id');
     process.env.APP_STORE_CONNECT_API_KEY_ISSUER_ID = core.getInput('app-store-connect-api-key-issuer-id');
     process.env.APP_STORE_CONNECT_API_KEY_BASE64 = core.getInput('app-store-connect-api-key-base64');
+    process.env.EXPORT_TEAM_ID = core.getInput("export-team-id");
 
     // Execute build.sh
     await exec.exec(`bash ${__dirname}/../build.sh`);


### PR DESCRIPTION
update_project_team and export_team_id have different roles. Make them available as options. 



Optional: Sometimes you need to specify a team id when exporting the ipa file

<img width="917" alt="image" src="https://user-images.githubusercontent.com/45959991/230599035-1102584f-f68a-4c3b-9cb4-51716484b44a.png">
