### PR TITLE
add custom-keychain-name input

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ App Store Connect API Key Issuer ID. Default `""`.
 
 Base64 encoded App Store Connect API Key. Default `""`.
 
+### `custom-keychain-name`
+
+Custom keychain name. Default `ios-build.keychain`
 
 ## Contributions Welcome!
 
@@ -202,6 +205,21 @@ Welcome your contributions!
 ```yaml
 - uses: yukiarrr/ios-build-action@v1.9.1
   with:
+    project-path: Unity-iPhone.xcodeproj
+    p12-key-base64: ${{ secrets.P12_KEY_BASE64 }}
+    p12-cer-base64: ${{ secrets.P12_CER_BASE64 }}
+    mobileprovision-base64: ${{ secrets.MOBILEPROVISION_BASE64 }}
+    code-signing-identity: ${{ secrets.CODE_SIGNING_IDENTITY }}
+    team-id: ${{ secrets.TEAM_ID }}
+    workspace-path: Unity-iPhone.xcworkspace # optional
+```
+
+### custom keychain name
+
+```yaml
+- uses: yukiarrr/ios-build-action@v1.9.1
+  with:
+    custom-keychain-name: my-ios-build.keychin # or {commit-hash}-ios-build.keychain
     project-path: Unity-iPhone.xcodeproj
     p12-key-base64: ${{ secrets.P12_KEY_BASE64 }}
     p12-cer-base64: ${{ secrets.P12_CER_BASE64 }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,9 +6,15 @@ platform :ios do
     decode_file
 
     keychain_password = SecureRandom.uuid
+    keychain_name = nil
+    if !ENV['CUSTOM_KEYCHAIN_NAME'].empty?
+      keychain_name = ENV['CUSTOM_KEYCHAIN_NAME']
+    else
+      keychain_name = 'ios-build.keychain'
+    end
 
     create_keychain(
-      name: 'ios-build.keychain',
+      name: keychain_name,
       password: keychain_password,
       default_keychain: true,
       unlock: true,
@@ -24,7 +30,7 @@ platform :ios do
             'ios-build-key.p12'
           end,
         certificate_password: ENV['CERTIFICATE_PASSWORD'],
-        keychain_name: 'ios-build.keychain',
+        keychain_name: keychain_name,
         keychain_password: keychain_password,
         log_output: true
       )
@@ -36,7 +42,7 @@ platform :ios do
             'ios-build-key.cer'
           end,
         certificate_password: ENV['CERTIFICATE_PASSWORD'],
-        keychain_name: 'ios-build.keychain',
+        keychain_name: keychain_name,
         keychain_password: keychain_password,
         log_output: true
       )
@@ -45,7 +51,7 @@ platform :ios do
         certificate_path:
           !ENV['P12_PATH'].empty? ? ENV['P12_PATH'] : 'ios-build.p12',
         certificate_password: ENV['CERTIFICATE_PASSWORD'],
-        keychain_name: 'ios-build.keychain',
+        keychain_name: keychain_name,
         keychain_password: keychain_password,
         log_output: true
       )
@@ -210,7 +216,7 @@ platform :ios do
       build_path: use_build_path ? ENV['BUILD_PATH'] : nil
     )
 
-    delete_keychain(name: 'ios-build.keychain')
+    delete_keychain(name: keychain_name)
   end
 
   # https://github.com/CocoaPods/Xcodeproj/issues/505#issuecomment-584699008

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ async function run() {
     process.env.APP_STORE_CONNECT_API_KEY_ISSUER_ID = core.getInput('app-store-connect-api-key-issuer-id');
     process.env.APP_STORE_CONNECT_API_KEY_BASE64 = core.getInput('app-store-connect-api-key-base64');
     process.env.BUILD_PATH = core.getInput('build-path');
+    process.env.CUSTOM_KEYCHAIN_NAME = core.getInput('custom-keychain-name');
 
     // Execute build.sh
     await exec.exec(`bash ${__dirname}/../build.sh`);


### PR DESCRIPTION
I use it in a self-hosted runner, and it often fails on the create_keychain step. This is especially true when building with multiple docker containers on a single macOS host. 

I added an input to allow for an arbitrary keychain name.
The default value uses the previously named `ios-build.keychain`.